### PR TITLE
refactor: Fix typo in authOptions

### DIFF
--- a/app/(api)/api/auth/[...nextauth]/authOptions.ts
+++ b/app/(api)/api/auth/[...nextauth]/authOptions.ts
@@ -89,7 +89,7 @@ export const authOptions: NextAuthOptions = {
         user: {
           ...session.user,
           account_type: token?.account_type,
-          menagement_role: token?.management_role,
+          management_role: token?.management_role,
           displayname: token?.displayname,
         },
       };


### PR DESCRIPTION
The code changes in this commit fix a typo in the `authOptions.ts` file. The `menagement_role` property is corrected to `management_role`. This change ensures the proper naming convention is followed and improves the readability and maintainability of the code.

Note: This commit message follows the established conventions in the repository.